### PR TITLE
chore: disable lcov CI plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
     steps:
       - uses: brianespinosa/checkout-setup-node-install@main
       - run: yarn test
-      - uses: vebr/jest-lcov-reporter@v0.2.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # - uses: vebr/jest-lcov-reporter@v0.2.1
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Temporarily disabling lcov plugin on CI because it does not work running on forks, even if the fork has been approved. Will need to come up with a different solution for outside contributors with lcov.