### PR TITLE
chore: daily dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     rebase-strategy: 'auto'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
     open-pull-requests-limit: 1
     ignore:
       - dependency-name: '*'


### PR DESCRIPTION
Since we are doing a large dependency group, we should aim to have daily dependabot updates so we do not accumulate too many updates happening at the same time.