### PR TITLE
chore: update probot/settings to extend centralized settings repo

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,19 +1,8 @@
-# https://github.com/brianespinosa/.github
-
-_extends: .github
+_extends: brianespinosa/settings:nextjs.yml
 
 repository:
-  # The name of the repository. Changing this will rename the repository
   name: tacomawedge
-
-  # A short description of the repository that will show up on GitHub
   description: Web site for Tacoma Wedge Historic District
-
-  # A URL with more information about the repository
   homepage: https://tacomawedge.org
-
-  # A comma-separated list of topics to set on the repository
   topics: react, nextjs, typescript
-
-  # Either `true` to make the repository private, or `false` to make it public.
   private: false


### PR DESCRIPTION
## Summary

- Replaces `_extends: .github` with `_extends: brianespinosa/settings:nextjs.yml`
- All existing `repository:` metadata preserved as-is
- Strips legacy comments from the file

## Why

Centralizes settings inheritance through `brianespinosa/settings` instead of the legacy `.github` repo fallback, consistent with the established pattern across all repos.