### PR TITLE
fix(deps): resolve 3 Dependabot alerts for js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "astro check"
   },
   "resolutions": {
+    "@astrojs/internal-helpers/js-yaml": ">=4.3.1 <5",
     "@vercel/backends/srvx": "^0.11.13",
     "@vercel/blob/undici": ">=6.28.0 <7",
     "@vercel/fastify/@tootallnate/once": "^3.0.1",
@@ -21,9 +22,11 @@
     "@vercel/node/esbuild": ">=0.28.1 <1",
     "@vercel/node/undici": ">=6.28.0 <7",
     "@vercel/prepare-flags-definitions/minimatch": "^10.2.3",
+    "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
     "@vercel/python-analysis/minimatch": "^10.2.3",
     "@vercel/sandbox/undici": ">=7.29.0 <8",
     "astro/esbuild": ">=0.28.1 <1",
+    "astro/js-yaml": ">=4.3.1 <5",
     "minimatch/brace-expansion": ">=5.0.7 <6",
     "tsx/esbuild": ">=0.28.1 <1",
     "vercel/esbuild": ">=0.28.1 <1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4965,25 +4965,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:>=4.3.1 <5":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/a52d0519f0f4ef5b4adc1cde466cb54c50d56e2b4a983b9d5c9c0f2f99462047007a6274d7e95617a21d3c91fde3ee6115536ed70991cd645ba8521058b78f77
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10/2bcec3a8118d7f744badeb04e14366578d234a736f353d41fe35d2305e4ce2409a8e041d277f07cd6bbc8aaa12128d650a68ce43247072519bede20962d2126f
+  checksum: 10/2ce71b5d632abbd77da80447bf860e8a0264e54bffe94840984887d58b023761495b523727547904517a6107a1ef189854b361e0fc44995ee13a84f222d7bd42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 3 Dependabot alert(s) for `js-yaml` by adding scoped resolutions
- Target version: >=4.3.1
- Resolved version: 4.3.1

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#155](https://github.com/brianespinosa/tacomawedge/security/dependabot/155) | GHSA-5p4m-2wfm-xmqj | high | 0% | Quadratic CPU consumption in `!!omap` resolution (3.x and 4.x) -- fix not backported |
| [#135](https://github.com/brianespinosa/tacomawedge/security/dependabot/135) | CVE-2026-59869 | high | 34.7% | YAML merge-key chains can force quadratic CPU consumption |
| [#132](https://github.com/brianespinosa/tacomawedge/security/dependabot/132) | CVE-2026-53550 | medium | 30.5% | Quadratic-complexity DoS in merge key handling via repeated aliases |

## Merge risk: High (8/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 1 | 4.1.1 -> 4.3.1 (minor) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 2 | imported in 10 module(s) for parents of js-yaml |
| Test signal | 2 | no test script, or tests could not run |
| Verification | 2 | one or more scripts skipped or partially run |

## Dependency chain

```
├─ @astrojs/internal-helpers@npm:0.10.2
│  └─ js-yaml@npm:4.3.0 (via npm:^4.3.0)
│
├─ @vercel/python-analysis@npm:0.13.1
│  └─ js-yaml@npm:4.1.1 (via npm:4.1.1)
│
├─ astro@npm:7.2.0
│  └─ js-yaml@npm:4.3.0 (via npm:^4.3.0)
│
└─ astro@npm:7.2.0 [2e3c1]
   └─ js-yaml@npm:4.3.0 (via npm:^4.3.0)
```

`js-yaml` is transitive, pulled in by three parents. `@vercel/python-analysis` pinned it exactly at the vulnerable `4.1.1` (npm alert #155 was scoped `runtime` via this path), while `@astrojs/internal-helpers` and `astro` both wanted `^4.3.0` (still vulnerable to #135/#132). All three parents needed scoped overrides to fully resolve.

## Changes

```json
"resolutions": {
  "@astrojs/internal-helpers/js-yaml": ">=4.3.1 <5",
  "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
  "astro/js-yaml": ">=4.3.1 <5"
}
```

## Verification

- [x] Lockfile validated: 1 resolved version (`4.3.1`) satisfies `>=4.3.1 <5`
- [x] `yarn build` (`astro build`) passes
- [x] `yarn typecheck` (`astro check`) passes -- 0 errors, 0 warnings, 0 hints
- [x] `yarn biome ci .` (matches the CI `biome` job) passes -- 1 unrelated info-level note about the schema version
- [x] `yarn knip` fails identically on this branch and on `main` (`PLAYWRIGHT_BASE_URL is not set` thrown while loading `playwright.config.ts`) -- pre-existing, unrelated to this change
- [ ] `yarn e2e` skipped -- requires a live Vercel preview deployment URL (`PLAYWRIGHT_BASE_URL`), which is only available in CI

No unit tests exist in this repo (Playwright e2e is the only test layer per `docs/adr/003-astro-over-nextjs.md`); e2e could not be run locally without a deployed preview, so CI is the verification signal for that layer.

## References

- https://github.com/brianespinosa/tacomawedge/security/dependabot/155
- https://github.com/brianespinosa/tacomawedge/security/dependabot/135
- https://github.com/brianespinosa/tacomawedge/security/dependabot/132