### PR TITLE
fix(deps): resolve Dependabot alert for brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vercel/prepare-flags-definitions/minimatch": "^10.2.3",
     "@vercel/python-analysis/minimatch": "^10.2.3",
     "astro/esbuild": ">=0.28.1 <1",
+    "minimatch/brace-expansion": ">=5.0.7 <6",
     "tsx/esbuild": ">=0.28.1 <1",
     "vercel/esbuild": ">=0.28.1 <1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3275,13 +3275,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"balanced-match@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "balanced-match@npm:1.0.2"
-  checksum: 10/9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -3317,22 +3310,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.18
-  resolution: "brace-expansion@npm:1.1.18"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-    concat-map: "npm:0.0.1"
-  checksum: 10/b55a3c03239b8d2127c7cbb3408c9ad3a556a8c303bf3064df78bfb7c093160fc8f6e0a32e42a850a78eba12f29ccf6ef997690b9acf945d242c56c61c4aa977
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:>=5.0.7 <6":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
+  checksum: 10/d8683d612919212c7cf298861acd1c15101e7e2ad186e7ae9747390e5b3fc9e9b55ce71107570d32985784d9d88fbbe438d725863aed7b0f3d08d5f080535eec
   languageName: node
   linkType: hard
 
@@ -3543,13 +3526,6 @@ __metadata:
   version: 2.0.0
   resolution: "common-ancestor-path@npm:2.0.0"
   checksum: 10/d15b61e109f993840bed09b893e2f533902f77c873004f0be7400b9147e6dc99c54f6eacec8c222bfe3d438697f757065c7747d4d9b2ae2c4f25ae523a85d828
-  languageName: node
-  linkType: hard
-
-"concat-map@npm:0.0.1":
-  version: 0.0.1
-  resolution: "concat-map@npm:0.0.1"
-  checksum: 10/9680699c8e2b3af0ae22592cb764acaf973f292a7b71b8a06720233011853a58e256c89216a10cbe889727532fd77f8bcd49a760cedfde271b8e006c20e079f2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 1 Dependabot alert for `brace-expansion` by adding a scoped `resolutions` override targeting the `minimatch` dependency chain
- Target version: >=5.0.7
- Resolved version: 5.0.9

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#133](https://github.com/brianespinosa/tacomawedge/security/dependabot/133) | CVE-2026-13149 | high | 27.5% | brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups |

## Merge risk: High (7/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 2 | 1.1.18 -> 5.0.9 (major) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of brace-expansion (build or tooling only) |
| Test signal | 2 | no test script, or tests could not run |
| Verification | 2 | one or more scripts skipped or partially run |

Note: the "before" version reflects the lowest resolved version of `brace-expansion` in the lockfile prior to this change (1.1.18, pulled in via `minimatch@3.1.5`, which was outside the vulnerable range). The actual vulnerable resolution was 5.0.5 via `minimatch@10.2.5`; installing merged both `minimatch` paths onto the single non-vulnerable 5.0.9 resolution.

## Dependency chain

```
├─ minimatch@npm:10.2.5
│  └─ brace-expansion@npm:5.0.5 (via npm:^5.0.5)
│
└─ minimatch@npm:3.1.5
   └─ brace-expansion@npm:1.1.18 (via npm:^1.1.7)
```

## Changes

```json
"resolutions": {
  "minimatch/brace-expansion": ">=5.0.7 <6"
}
```

## Verification

- [x] Lockfile validated: 1 resolved version (5.0.9) satisfies `>=5.0.7 <6`
- [x] `yarn build` passes
- [x] `yarn typecheck` passes
- [x] `yarn check` passes (biome; pre-existing schema-version info notice, unrelated to this change)
- [ ] `yarn knip` fails identically on `main` (`PLAYWRIGHT_BASE_URL is not set`) — pre-existing, unrelated to this change; confirmed by running knip against `origin/main` in a separate worktree
- [ ] `yarn e2e` skipped — requires `PLAYWRIGHT_BASE_URL` set to a real Vercel preview deployment URL; not fabricated locally, deferred to CI

## References

- https://github.com/brianespinosa/tacomawedge/security/dependabot/133
